### PR TITLE
MBS-9445: Add trimming to store-method of chatgpt-instance

### DIFF
--- a/tools/chatgpt/classes/instance.php
+++ b/tools/chatgpt/classes/instance.php
@@ -72,9 +72,9 @@ class instance extends base_instance {
         $this->set_endpoint($endpoint);
 
         $this->set_customfield2($enabled);
-        $this->set_customfield3($resourcename);
-        $this->set_customfield4($deploymentid);
-        $this->set_customfield5($apiversion);
+        $this->set_customfield3(trim($resourcename));
+        $this->set_customfield4(trim($deploymentid));
+        $this->set_customfield5(trim($apiversion));
     }
 
     #[\Override]


### PR DESCRIPTION
Added trim()-function to `extend_store_formdata`-method of ChatGPT-instance. 