### PR TITLE
YULMS-2: Fix to Prevent fatal error in get_custom_error_message when …

### DIFF
--- a/tools/chatgpt/classes/connector.php
+++ b/tools/chatgpt/classes/connector.php
@@ -159,8 +159,9 @@ class connector extends \local_ai_manager\base_connector {
         $message = '';
         switch ($code) {
             case 400:
-                if (method_exists($exception, 'getResponse') && !empty($exception->getResponse())) {
-                    $responsebody = json_decode($exception->getResponse()->getBody()->getContents());
+		$response = method_exists($exception, 'getResponse') ? $exception->getResponse() : null;
+		if (!empty($response)) {
+   		 $responsebody = json_decode($response->getBody()->getContents());
                     if (property_exists($responsebody, 'error') && property_exists($responsebody->error, 'code')
                             && $responsebody->error->code === 'content_filter') {
                         $message = get_string('err_contentfilter', 'aitool_chatgpt');


### PR DESCRIPTION
**Problem**
In the ChatGPT connector of the moodle-local_ai_manager plugin, a fatal error occurs during failed API requests when the thrown exception is a ConnectException.
 
The code attempts to call $exception->getResponse() without checking if the method exists. Unfortunately, ConnectException does not implement getResponse(), leading to:

PHP Fatal error:  Uncaught Error: Call to undefined method GuzzleHttp\Exception\ConnectException::getResponse()

**Root Cause**
The connector was making multiple direct calls to getResponse() on any exception object passed to the error handler. Some exceptions (e.g., ConnectException) do not implement this method, resulting in a fatal crash.

**Solution**
Introduced a safe check using method_exists() to verify the existence of getResponse() before calling it. The response is now stored in a variable to avoid redundant method calls and improve readability.

**Benefits**
- Prevents fatal errors in AI evaluation workflows during network or API outages.
- Makes error handling in get_custom_error_message() fault-tolerant.

**Affected file**
local/ai_manager/tools/chatgpt/classes/connector.php 

**Notes**
This issue surfaced when the AI service was unreachable (Because of a negative account balance) and the Moodle instance had local AI Manager enabled with the ChatGPT connector. This patch ensures safe fallback behavior in all such cases.
An added complication is that the error reported appears in the UI of the plugin being used. In my  case, this was https://github.com/marcusgreen/moodle-qtype_aitext. Users might think the issue is with the qtype_aitext plugin but it is really with local_ai_manager